### PR TITLE
Fixed issue in blurple.io.reply.Reply._validate_reply.

### DIFF
--- a/blurple/io/reply.py
+++ b/blurple/io/reply.py
@@ -131,8 +131,8 @@ class Reply(ABC):
             return content in valid
         if callable(valid):
             if inspect.iscoroutinefunction(object):
-                return await valid()
-            return valid()
+                return await valid(reply)
+            return valid(reply)
 
     @staticmethod
     def _get_reply_content(reply):


### PR DESCRIPTION
Documentation states that Reply super classes should be able to accept a Callable and the Callable will recieve the reply object.

Currently the Callable does not recieve the reply object.